### PR TITLE
make wifi settings in Automatic.Configuration obsolete

### DIFF
--- a/automatic.proto
+++ b/automatic.proto
@@ -11,60 +11,67 @@ import "touch.proto";
 package oak.platform;
 
 service Automatic {
-  /* Enables configuration when the Platform starts.
+  // Enables configuration when the Platform starts.
 
-     This is used to make settings "permanent", such as ensuring the
-     rotation of a monitor and resetting WiFi connection settings
-     after a reboot.
+  // This is used to make settings "permanent", such as ensuring the
+  // rotation of a monitor and touch calibration after a reboot.
 
-     When the Platform starts, the Apply RPC is called using the
-     Configuration message that was previously passed to the Store
-     RPC. It is also possible to manually use the Apply RPC at any
-     other time. The automatic configuration is NOT applied every time
-     an application starts. It is only after the Platform is
-     restarted, which is normally only after a reboot.
+  // Note that network connection settings are persisted
+  // independently. See `network.proto` for more details.
 
-     Requests in the fields of the stored Configuration message are
-     sent, one at a time, in the order they are shown in the
-     Configuration message definition below, to the appropriate RPCs
-     of the services where those message types are defined.
+  // When the Platform starts, the Apply RPC is called using the
+  // Configuration message that was previously passed to the Store
+  // RPC. It is also possible to manually use the Apply RPC at any
+  // other time. The automatic configuration is NOT applied every time
+  // an application starts. It is only after the Platform is
+  // restarted, which is normally only after a reboot.
 
-     Instead of creating the Configuration message by hand, it is
-     recommended that all of the configuration for each other service
-     is prepared at once and then the Generate RPC is used to create a
-     Configuration message that would match the prepared state. Then
-     that message can be passed to the Store RPC. This is essentially
-     a "Save Configuration" flow.
+  // Requests in the fields of the stored Configuration message are
+  // sent, one at a time, in the order they are shown in the
+  // Configuration message definition below, to the appropriate RPCs
+  // of the services where those message types are defined.
 
-     If there is an error in any of the configuration requests, then
-     the Apply RPC will stop executing at that point. When the cause
-     of the issue is fixed, such as if a missing hardware component
-     was reconnected, then the Apply endpoint can be called again to
-     retry the automatic configuration. */
+  // Instead of creating the Configuration message by hand, it is
+  // recommended that all of the configuration for each other service
+  // is prepared at once and then the Generate RPC is used to create a
+  // Configuration message that would match the prepared state. Then
+  // that message can be passed to the Store RPC. This is essentially
+  // a "Save Configuration" flow.
+
+  // If there is an error in any of the configuration requests, then
+  // the Apply RPC will stop executing at that point. When the cause
+  // of the issue is fixed, such as if a missing hardware component
+  // was reconnected, then the Apply endpoint can be called again to
+  // retry the automatic configuration.
 
   // Stores a Configuration for automatic application on start-up
   rpc Store (Configuration) returns (google.protobuf.Empty) {}
+
   // Exposes the currently stored Configuration
   rpc View (google.protobuf.Empty) returns (Configuration) {}
+
   // Erases the currently stored Configuration so that no automatic
-  // configuration will be done on next Platform startup
+  // configuration will be done on next Platform start-up.
   rpc Clear (google.protobuf.Empty) returns (google.protobuf.Empty) {}
+
   // Creates a Configuration message that, when sent to the Store RPC,
   // would lead to automatic configuration resulting in the same
   // settings that are in place when Generate was called
   rpc Generate (google.protobuf.Empty) returns (Configuration) {}
+
   // Uses the stored Configuration message to configure the
   // appropriate other services
   rpc Apply (google.protobuf.Empty) returns (google.protobuf.Empty) {}
 }
 
 message Configuration {
-  /* The Configuration message contains configuration request messages
-     from other services. See the matching .proto files. */
+  // The Configuration message contains configuration request messages
+  // from other services. See the matching .proto files.
+
   repeated oak.platform.AudioConfigurationRequest audio = 1;
   repeated oak.platform.DisplayConfigurationRequest display = 2;
   oak.platform.DisplayGlobalConfiguration display_global = 3;
-  repeated oak.platform.WiFiConnectionSettings wifi = 4;
+  repeated oak.platform.WiFiConnectionSettings OBSOLETE_wifi = 4;
   repeated oak.platform.TouchConfigurationRequest touch = 5;
   oak.platform.DotDashPayConfiguration dotdashpay = 6;
 }

--- a/network.proto
+++ b/network.proto
@@ -5,11 +5,11 @@ import "google/protobuf/empty.proto";
 package oak.platform;
 
 service Network {
-  /* View and configure host's networking settings.
+  // View and configure host's networking settings.
 
-     Currently, only WPA-PSK WiFi networks are supported. Wired
-     network connections cannot be altered and should be configured
-     via DHCP. */
+  // Currently, only WPA-PSK WiFi networks are supported. Wired
+  // network connections cannot be altered and should be configured
+  // via DHCP.
 
   // Shows network information for all Ethernet and WiFi devices,
   // including current network addresses and MAC addresses.
@@ -17,12 +17,16 @@ service Network {
 
   // Lists visible WiFi networks using the first available WiFi interface
   rpc WiFiScan (google.protobuf.Empty) returns (WiFiScanResults) {}
+
   // Adds or overwrites configuration for connecting to a specific
   // WiFi network. The host will then attempt to connect to the
-  // network whenever it is available.
+  // network whenever it is available. These settings are persisted
+  // until `ForgetWifi` is used.
   rpc AddWiFi (WiFiConnectionSettings) returns (google.protobuf.Empty) {}
+
   // Removes stored WiFi configuration.
   rpc ForgetWiFi (WiFiConnectionSettings) returns (google.protobuf.Empty) {}
+
   // Lists the WiFi network configurations that are available to this host.
   rpc ListKnownWiFiNetworks (google.protobuf.Empty) returns (WiFiNetworkList) {}
 }
@@ -57,11 +61,12 @@ message WiFiScanResults {
 }
 
 message WiFiConnectionSettings {
+
   // Settings are WPA-PSK, also known as WPA-Personal.
   // This is currently all that is supported.
   string ssid = 1;
-  // 'passphrase' will be stored securely and CANNOT be retrieved via
-  // this service.
+
+  // 'passphrase' will be stored securely and CANNOT be viewed.
   string passphrase = 2;
 }
 


### PR DESCRIPTION
Lots of docs cleanup too, but the relevant part is `automatic.py:67`