### PR TITLE
One call to configure them all

### DIFF
--- a/audio.proto
+++ b/audio.proto
@@ -1,4 +1,3 @@
-
 syntax = "proto3";
 
 import "google/protobuf/empty.proto";
@@ -10,23 +9,25 @@ package oak.platform;
 //
 // Microphones are not supported.
 //
-// 'mixer_id' values come from the available ports on the host
-// device regardless of whether an audio device is connected.
+// Mixer IDs values come from the available ports on the host device,
+// sometimes regardless of whether an audio device is connected.
 service Audio {
 
-  // Lists available mixers which correspond to connected audio
-  // devices; also shows the current configuration, i.e. volume and
-  // mute settings
-  // You may have to guess-and-check to determine which mixer
-  // corresponds to the physical device you want to control.
+  // Shows the current configuration of audio mixers.
+  // Each mixer controls the output of a different speaker.
   rpc Current (google.protobuf.Empty) returns (MultiAudioConfiguration) {}
 
-  // Applies configuration to an audio device, i.e. change the volume
+  // Applies configuration to audio mixers
+  // If a specified mixer is not present on the host, it is silently
+  // skipped.
   rpc Configure (MultiAudioConfiguration) returns (google.protobuf.Empty) {}
 }
 
 message MultiAudioConfiguration {
+
+  // Maps the Mixer ID to its configuration
   map<string,AudioConfiguration> mixers = 1;
+
   message AudioConfiguration {
 
     // Mutes the mixer

--- a/audio.proto
+++ b/audio.proto
@@ -1,3 +1,4 @@
+
 syntax = "proto3";
 
 import "google/protobuf/empty.proto";
@@ -18,27 +19,21 @@ service Audio {
   // mute settings
   // You may have to guess-and-check to determine which mixer
   // corresponds to the physical device you want to control.
-  rpc Info (google.protobuf.Empty) returns (AudioInformation) {}
+  rpc Current (google.protobuf.Empty) returns (MultiAudioConfiguration) {}
+
   // Applies configuration to an audio device, i.e. change the volume
-  rpc Configure (AudioConfigurationRequest) returns (google.protobuf.Empty) {}
+  rpc Configure (MultiAudioConfiguration) returns (google.protobuf.Empty) {}
 }
 
-message AudioInformation {
-  repeated Mixer mixers = 1;
-  message Mixer {
-    string mixer_id = 1;
-    AudioConfiguration configuration = 2;
+message MultiAudioConfiguration {
+  map<string,AudioConfiguration> mixers = 1;
+  message AudioConfiguration {
+
+    // Mutes the mixer
+    bool mute = 1;
+
+    // Must be between 0 and 100 inclusive
+    // 0 is effectively mute and 100 is maximum volume
+    uint32 volume = 2;
   }
-}
-
-message AudioConfigurationRequest {
-  string mixer_id = 1;
-  AudioConfiguration configuration = 2;
-}
-
-message AudioConfiguration {
-  bool mute = 1;
-  // Must be between 0 and 100 inclusive
-  // 0 is effectively mute and 100 is maximum volume
-  uint32 volume = 2;
 }

--- a/automatic.proto
+++ b/automatic.proto
@@ -65,7 +65,7 @@ service Automatic {
 // The Configuration message contains configuration request messages
 // from other services. See the matching .proto files.
 message Configuration {
-  repeated oak.platform.AudioConfigurationRequest audio = 1;
+  oak.platform.MultiAudioConfiguration audio = 1;
   oak.platform.MultiDisplayConfiguration display = 2;
-  repeated oak.platform.InputConfigurationRequest input = 5;
+  oak.platform.MultiInputConfiguration input = 3;
 }

--- a/automatic.proto
+++ b/automatic.proto
@@ -35,11 +35,8 @@ package oak.platform;
 // that message can be passed to the Store RPC. This is essentially
 // a "Save Configuration" flow.
 //
-// If there is an error in any of the configuration requests, then
-// the Apply RPC will stop executing at that point. When the cause
-// of the issue is fixed, such as if a missing hardware component
-// was reconnected, then the Apply endpoint can be called again to
-// retry the automatic configuration.
+// If any errors are returned by RPCs to the Apply RPC, the error
+// messages are collected and return as an error from the Apply RPC.
 service Automatic {
 
   // Stores a Configuration for automatic application on start-up
@@ -65,7 +62,13 @@ service Automatic {
 // The Configuration message contains configuration request messages
 // from other services. See the matching .proto files.
 message Configuration {
+
+  // Message to be sent to Audio.Configure RPC
   oak.platform.MultiAudioConfiguration audio = 1;
+
+  // Message to be sent to Display.Configure RPC
   oak.platform.MultiDisplayConfiguration display = 2;
+
+  // Message to be sent to Input.Configure RPC
   oak.platform.MultiInputConfiguration input = 3;
 }

--- a/display.proto
+++ b/display.proto
@@ -27,22 +27,22 @@ package oak.platform;
 // display is plugged into e.g. "HDMI1" and "DP1".
 service Display {
 
-  // Lists displays, current configuration and supported configurations
+  // Lists displays and their supported configurations
   rpc Info (google.protobuf.Empty) returns (DisplayInformation) {}
+
+  // Shows current configuration for all displays
+  rpc Current (google.protobuf.Empty) returns (MultiDisplayConfiguration) {}
 
   // Set configuration for all displays
   // Displays not specified in the MultiDisplayConfiguration will be
-  // turned on and set to the preferred mode.
+  // turned on and set to their `preferred_mode`.
   rpc Configure (MultiDisplayConfiguration) returns (google.protobuf.Empty) {}
 }
 
 message DisplayInformation {
 
-  // Current configuration of all displays
-  MultiDisplayConfiguration current_configuration = 1;
-
   // Maps display_id to what modes the connected display supports
-  map<string,DisplayCapabilities> display_capabilities = 2;
+  map<string,DisplayCapabilities> displays = 2;
 
   message DisplayCapabilities {
 
@@ -62,32 +62,32 @@ message MultiDisplayConfiguration {
 
   // Map display_id to per-display configuration
   map<string,DisplayConfiguration> displays = 2;
-}
 
-message DisplayConfiguration {
+  message DisplayConfiguration {
 
-  // Disables the display
-  // This does not actually "power off" the display however
-  bool off = 1;
+    // Disables the display
+    // This does not actually "power off" the display however
+    bool off = 1;
 
-  // Resolution and frame-rate
-  // Value should be taken from Display.Info response
-  // Use empty-string to automatically use the "preferred_mode"
-  string mode = 2;
+    // Resolution and frame-rate
+    // Value should be taken from Display.Info response
+    // Use empty-string to automatically use the "preferred_mode"
+    string mode = 2;
 
-  // Rotation and reflection of display image
-  // FORWARD_* means only rotating
-  // BACKWARD_* means flip on the horizontal axis before rotating
-  Orientation orientation = 3;
-}
+    // Rotation and reflection of display image
+    // FORWARD_* means only rotating
+    // BACKWARD_* means flip on the horizontal axis before rotating
+    Orientation orientation = 3;
 
-enum Orientation {
-  FORWARD_UPRIGHT = 0;
-  FORWARD_LEFT = 1;
-  FORWARD_RIGHT = 2;
-  FORWARD_INVERTED = 3;
-  BACKWARD_UPRIGHT = 4;
-  BACKWARD_LEFT = 5;
-  BACKWARD_RIGHT = 6;
-  BACKWARD_INVERTED = 7;
+    enum Orientation {
+      FORWARD_UPRIGHT = 0;
+      FORWARD_LEFT = 1;
+      FORWARD_RIGHT = 2;
+      FORWARD_INVERTED = 3;
+      BACKWARD_UPRIGHT = 4;
+      BACKWARD_LEFT = 5;
+      BACKWARD_RIGHT = 6;
+      BACKWARD_INVERTED = 7;
+    }
+  }
 }

--- a/display.proto
+++ b/display.proto
@@ -23,7 +23,7 @@ package oak.platform;
 // mode to a display if it is not listed in that display's
 // 'available_modes'.
 //
-// 'display_id' values come from the name of the physical port the
+// Display IDs values come from the name of the physical port the
 // display is plugged into e.g. "HDMI1" and "DP1".
 service Display {
 
@@ -36,12 +36,13 @@ service Display {
   // Set configuration for all displays
   // Displays not specified in the MultiDisplayConfiguration will be
   // turned on and set to their `preferred_mode`.
+  // If a specified display is unplugged it is silently skipped.
   rpc Configure (MultiDisplayConfiguration) returns (google.protobuf.Empty) {}
 }
 
 message MultiDisplayInformation {
 
-  // Maps display_id to what modes the connected display supports
+  // Maps Display IDs to what modes the connected display supports
   map<string,DisplayCapabilities> displays = 2;
 
   message DisplayCapabilities {
@@ -60,7 +61,7 @@ message MultiDisplayConfiguration {
   // If 0 is specified, the default of 96 will be used
   uint32 dpi = 1;
 
-  // Map display_id to per-display configuration
+  // Map Display IDs to per-display configuration
   map<string,DisplayConfiguration> displays = 2;
 
   message DisplayConfiguration {

--- a/display.proto
+++ b/display.proto
@@ -28,7 +28,7 @@ package oak.platform;
 service Display {
 
   // Lists displays and their supported configurations
-  rpc Info (google.protobuf.Empty) returns (DisplayInformation) {}
+  rpc Info (google.protobuf.Empty) returns (MultiDisplayInformation) {}
 
   // Shows current configuration for all displays
   rpc Current (google.protobuf.Empty) returns (MultiDisplayConfiguration) {}
@@ -39,7 +39,7 @@ service Display {
   rpc Configure (MultiDisplayConfiguration) returns (google.protobuf.Empty) {}
 }
 
-message DisplayInformation {
+message MultiDisplayInformation {
 
   // Maps display_id to what modes the connected display supports
   map<string,DisplayCapabilities> displays = 2;

--- a/input.proto
+++ b/input.proto
@@ -11,53 +11,44 @@ package oak.platform;
 service Input {
 
   // Lists input interfaces that can be configured
-  rpc Info (google.protobuf.Empty) returns (InputInformation) {}
+  rpc Current (google.protobuf.Empty) returns (MultiInputConfiguration) {}
 
   // Applies configuration to a input interface
-  rpc Configure (InputConfigurationRequest) returns (InputConfiguration) {}
+  rpc Configure (MultiInputConfiguration) returns (google.protobuf.Empty) {}
 }
 
-message InputInformation {
-  repeated InputDevice input_devices = 1;
-  message InputDevice {
-    string input_device_id = 1;
-    InputConfiguration configuration = 2;
-  }
-}
+message MultiInputConfiguration {
+  map<string,InputConfiguration> inputs = 1;
 
-message InputConfigurationRequest {
-  string input_device_id = 1;
-  InputConfiguration configuration = 2;
-}
+  message InputConfiguration {
 
-message InputConfiguration {
+    // Four space-separated integers representing
+    // <min-x max-x min-y max-y>
+    // Use empty-string to use default calibration. Note that once
+    // calibration is changed it can only be reset to default by
+    // rebooting.
+    // It is recommended that you start with extreme values,
+    // such as "0 32768 0 32768", and then manually change values one
+    // axis at a time until physical inputes are aligned as desired.
+    string calibration = 1;
 
-  // Four space-separated integers representing
-  // <min-x max-x min-y max-y>
-  // Use empty-string to use default calibration. Note that once
-  // calibration is changed it can only be reset to default by
-  // rebooting.
-  // It is recommended that you start with extreme values,
-  // such as "0 32768 0 32768", and then manually change values one
-  // axis at a time until physical inputes are aligned as desired.
-  string calibration = 1;
+    // Direction the plane of input is oriented relative to the input
+    // interface's upright orientation. This is configured independently
+    // of any display's orientation.
+    // FORWARD_* means facing the user as a monitor normally does
+    // BACKWARD_* means turned around (the X axis is reversed) before rotating
+    // LEFT and RIGHT mean quarter turns relative to user's perspective
+    Orientation orientation = 2;
 
-  // Direction the plane of input is oriented relative to the input
-  // interface's upright orientation. This is configured independently
-  // of any display's orientation.
-  // FORWARD_* means facing the user as a monitor normally does
-  // BACKWARD_* means turned around (the X axis is reversed) before rotating
-  // LEFT and RIGHT mean quarter turns relative to user's perspective
-  Orientation orientation = 2;
-
-  enum Orientation {
-    FORWARD_UPRIGHT = 0;
-    FORWARD_LEFT = 1;
-    FORWARD_RIGHT = 2;
-    FORWARD_INVERTED = 3;
-    BACKWARD_UPRIGHT = 4;
-    BACKWARD_LEFT = 5;
-    BACKWARD_RIGHT = 6;
-    BACKWARD_INVERTED = 7;
+    enum Orientation {
+      FORWARD_UPRIGHT = 0;
+      FORWARD_LEFT = 1;
+      FORWARD_RIGHT = 2;
+      FORWARD_INVERTED = 3;
+      BACKWARD_UPRIGHT = 4;
+      BACKWARD_LEFT = 5;
+      BACKWARD_RIGHT = 6;
+      BACKWARD_INVERTED = 7;
+    }
   }
 }

--- a/input.proto
+++ b/input.proto
@@ -6,18 +6,23 @@ package oak.platform;
 
 // Configure human input interfaces (mice and touch sensors)
 //
-// 'input_device_id' values come from serial numbers reported by the
+// Input IDs come from serial numbers reported by the
 // input devices themselves.
 service Input {
 
-  // Lists input interfaces that can be configured
+  // Shows configurable input interfaces and their current
+  // configurations.
   rpc Current (google.protobuf.Empty) returns (MultiInputConfiguration) {}
 
   // Applies configuration to a input interface
+  // If an input device is not present on the host, it is silently
+  // skipped.
   rpc Configure (MultiInputConfiguration) returns (google.protobuf.Empty) {}
 }
 
 message MultiInputConfiguration {
+
+  // Maps the Input ID to its configuration
   map<string,InputConfiguration> inputs = 1;
 
   message InputConfiguration {


### PR DESCRIPTION
This changes Audio, Display, and Input services Configure RPCs to configure multiple devices with one call instead of one call per device. Automatic is updated to reflect changes.

This makes each of those services more consistent and enables a very simple workflow of fetching, modifying, and sending configuration.